### PR TITLE
Resolve warnings due to missing parens

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,11 +11,11 @@ defmodule PlugHeartbeat.Mixfile do
     [app: :plug_heartbeat,
      version: @version,
      elixir: "~> 1.0",
-     deps: deps,
+     deps: deps(),
      description: @description,
      name: "PlugHeartbeat",
      source_url: @github_url,
-     package: package]
+     package: package()]
   end
 
   def application do


### PR DESCRIPTION
Hello there 👋 

Thank you for writing this plug. This PR hopes to resolve a few warnings that appear during compilation:

```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /.../deps/plug_heartbeat/mix.exs:14: PlugHeartbeat.Mixfile.project/0

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /.../deps/plug_heartbeat/mix.exs:18: PlugHeartbeat.Mixfile.project/0
```

Thanks for your contributions to the language and community!